### PR TITLE
Fixed "settings did not save" in Chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# About (Damianoux)
+
+Changed settings.js so that settings are correctly saved to Application Storage in latest versions of Chrome
+
 # About
 
 This is a fork of: https://github.com/NayamAmarshe/firefox-multi-touch-zoom

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -1,4 +1,4 @@
-let storageArea = browser.storage.local;
+let storageArea = chrome.storage.local;
 
 function restoreOptions() {
   var gettingItem = storageArea.get([


### PR DESCRIPTION
settings.js: changed "browser" to "chrome", abd now settings are persisted in the app storage.